### PR TITLE
Basic after_change hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Counting and aggregation library for Rails.
   - [Recalculating a counter](#recalculating-a-counter)
   - [Reset a counter](#reset-a-counter)
   - [Verify a counter](#verify-a-counter)
+  - [Hooks](#hooks)
   - [TODO](#todo)
   - [Usage](#usage)
   - [Installation](#installation)
@@ -254,12 +255,29 @@ store.product_revenue.correct! #=> false
 store.product_revenue #=>200
 ```
 
+## Hooks
+
+You can add an `after_change` hook to your counter definition to perform some action when the counter is updated. For example, you might want to send a notification when a counter reaches a certain value.
+
+```ruby
+class OrderRevenueCounter < Counter::Definition
+  count :orders, as: :order_revenue
+  sum :price
+
+  after_change :send_congratulations_email
+
+  def send_congratulations_email counter, from, to
+    return unless from < 1000 && to >= 1000
+    send_email "Congratulations! You've made #{to} dollars!"
+  end
+end
+```
+
 ---
 
 ## TODO
 
 See the asociated project in Github but roughly I'm thinking:
-- Support callbacks/hooks for when a counter is incremented/decremented. This would allow us to do things like send a notification when a counter reaches a certain value or crosses a threshold.
 - Hierarchical counters. For example, a Site sends many Newsletters and each Newsletter results in many EmailMessages. Each EmailMessage can be marked as spam. How do you create counters for how many spam emails were sent at the Newsletter level and the Site level?
 - Time-based counters for analytics. Instead of a User having one OrderRevenue counter, they would have an OrderRevenue counter for each day. These counters would then be used to produce a chart of their product revenue over the month. Not sure if these are just special counters or something else entirely? Do they use the same ActiveRecord model?
 - Can we support floating point values? Sounds useful but don't have a use case for it right now. Would they need to be a different ActiveRecord table?

--- a/app/models/concerns/counter/hooks.rb
+++ b/app/models/concerns/counter/hooks.rb
@@ -10,7 +10,7 @@ module Counter::Hooks
 
       from, to = previous_changes["value"]
       definition.counter_hooks.each do |hook|
-        hook.call self, from, to
+        definition.send(hook, self, from, to)
       end
     end
   end

--- a/app/models/concerns/counter/hooks.rb
+++ b/app/models/concerns/counter/hooks.rb
@@ -3,7 +3,7 @@ module Counter::Hooks
   extend ActiveSupport::Concern
 
   included do
-    after_update :call_counter_hooks
+    after_save :call_counter_hooks
 
     def call_counter_hooks
       return unless previous_changes["value"]

--- a/app/models/concerns/counter/hooks.rb
+++ b/app/models/concerns/counter/hooks.rb
@@ -1,0 +1,17 @@
+# Allow hooks to be defined on the counter
+module Counter::Hooks
+  extend ActiveSupport::Concern
+
+  included do
+    after_update :call_counter_hooks
+
+    def call_counter_hooks
+      return unless previous_changes["value"]
+
+      from, to = previous_changes["value"]
+      definition.counter_hooks.each do |hook|
+        hook.call self, from, to
+      end
+    end
+  end
+end

--- a/app/models/counter/value.rb
+++ b/app/models/counter/value.rb
@@ -36,6 +36,7 @@ class Counter::Value < ApplicationRecord
   end
 
   include Counter::Definable
+  include Counter::Hooks
   include Counter::Increment
   include Counter::Reset
   include Counter::Recalculatable

--- a/lib/counter/definition.rb
+++ b/lib/counter/definition.rb
@@ -32,6 +32,8 @@ class Counter::Definition
   attr_accessor :name
   # An array of all global counters
   attr_writer :global_counters
+  # An array of Proc to run when the counter changes
+  attr_writer :counter_hooks
 
   def sum?
     column_to_count.present?
@@ -73,6 +75,11 @@ class Counter::Definition
     @global_counters
   end
 
+  def counter_hooks
+    @counter_hooks ||= []
+    @counter_hooks
+  end
+
   # Set the association we're counting
   def self.count association_name, as: "#{association_name}_counter"
     instance.association_name = association_name
@@ -106,5 +113,9 @@ class Counter::Definition
 
     instance.conditions[action] ||= []
     instance.conditions[action] << conditions
+  end
+
+  def self.after_change block
+    instance.counter_hooks << block
   end
 end

--- a/lib/counter/definition.rb
+++ b/lib/counter/definition.rb
@@ -34,6 +34,8 @@ class Counter::Definition
   attr_writer :global_counters
   # An array of Proc to run when the counter changes
   attr_writer :counter_hooks
+  # An array of all global counters
+  attr_writer :global_counters
 
   def sum?
     column_to_count.present?
@@ -78,6 +80,11 @@ class Counter::Definition
   def counter_hooks
     @counter_hooks ||= []
     @counter_hooks
+  end
+
+  def global_counters
+    @global_counters ||= []
+    @global_counters
   end
 
   # Set the association we're counting

--- a/test/dummy/app/models/order_revenue_counter.rb
+++ b/test/dummy/app/models/order_revenue_counter.rb
@@ -1,4 +1,11 @@
 class OrderRevenueCounter < Counter::Definition
   count :orders, as: :order_revenue
   sum :price
+
+  after_change ->(instance, from, to) { send_congratulations_email from, to }
+
+  def self.send_congratulations_email from, to
+    return unless from < 1000 && to >= 1000
+    puts "Congratulations! You've made #{to} dollars!"
+  end
 end

--- a/test/dummy/app/models/order_revenue_counter.rb
+++ b/test/dummy/app/models/order_revenue_counter.rb
@@ -2,9 +2,9 @@ class OrderRevenueCounter < Counter::Definition
   count :orders, as: :order_revenue
   sum :price
 
-  after_change ->(instance, from, to) { send_congratulations_email from, to }
+  after_change :send_congratulations_email
 
-  def self.send_congratulations_email from, to
+  def send_congratulations_email counter, from, to
     return unless from < 1000 && to >= 1000
     puts "Congratulations! You've made #{to} dollars!"
   end

--- a/test/integration/counters_test.rb
+++ b/test/integration/counters_test.rb
@@ -194,7 +194,12 @@ class CountersTest < ActiveSupport::TestCase
     u = User.create!
     product = u.products.create!
     u.orders.create! product: product, price: 500
+
     assert_output "Congratulations! You've made 1000 dollars!\n" do
+      u.orders.create! product: product, price: 500
+    end
+
+    assert_output "" do
       u.orders.create! product: product, price: 500
     end
   end

--- a/test/integration/counters_test.rb
+++ b/test/integration/counters_test.rb
@@ -189,4 +189,13 @@ class CountersTest < ActiveSupport::TestCase
     product.destroy
     assert_equal 0, u.premium_products_counter.value
   end
+
+  test "allows hooks to be defined on the counter" do
+    u = User.create!
+    product = u.products.create!
+    u.orders.create! product: product, price: 500
+    assert_output "Congratulations! You've made 1000 dollars!\n" do
+      u.orders.create! product: product, price: 500
+    end
+  end
 end

--- a/test/integration/counters_test.rb
+++ b/test/integration/counters_test.rb
@@ -193,8 +193,11 @@ class CountersTest < ActiveSupport::TestCase
   test "allows hooks to be defined on the counter" do
     u = User.create!
     product = u.products.create!
+    assert_output "Congratulations! You've made 1000 dollars!\n" do
+      u.orders.create! product: product, price: 1000
+    end
+    product.order_revenue.reset!
     u.orders.create! product: product, price: 500
-
     assert_output "Congratulations! You've made 1000 dollars!\n" do
       u.orders.create! product: product, price: 500
     end


### PR DESCRIPTION
This is a basic implementation of an after_change hook for a counter. It can be added as

```ruby
after_change :send_confirmation_email

def send_confirmation_email counter, from, to
  return unless from < 1000 && to >= 1000

  # Send your email only when the counter crosses 1000
end
```

Resolves #7 