### PR TITLE
Refactor the conditional definition to be cleaner

### DIFF
--- a/app/models/concerns/counter/increment.rb
+++ b/app/models/concerns/counter/increment.rb
@@ -19,22 +19,25 @@ module Counter::Increment
     end
 
     def add_item item
-      return unless accept_item?(item, :create)
+      return unless increment?(item, :create)
 
       increment! by: increment_from_item(item)
     end
 
     def remove_item item
-      return unless accept_item?(item, :delete)
+      return unless decrement?(item, :delete)
 
       decrement! by: increment_from_item(item)
     end
 
     def update_item item
-      return unless definition.filters && definition.filters[:update]
+      if increment?(item, :update)
+        increment! by: increment_from_item(item)
+      end
 
-      change = definition.filters[:update].call item
-      increment! by: change * increment_from_item(item)
+      if decrement?(item, :update)
+        decrement! by: increment_from_item(item)
+      end
     end
 
     # How much should we increment the counter

--- a/lib/counter.rb
+++ b/lib/counter.rb
@@ -4,6 +4,7 @@ require "counter/railtie"
 require "counter/integration/counters"
 require "counter/integration/countable"
 require "counter/any"
+require "counter/conditions"
 require "counter/error"
 
 module Counter

--- a/lib/counter/conditions.rb
+++ b/lib/counter/conditions.rb
@@ -1,0 +1,16 @@
+class Counter::Conditions
+  attr_accessor :increment_conditions, :decrement_conditions
+
+  def initialize
+    @increment_conditions = []
+    @decrement_conditions = []
+  end
+
+  def increment_if block
+    increment_conditions << block
+  end
+
+  def decrement_if block
+    decrement_conditions << block
+  end
+end

--- a/test/dummy/app/models/premium_product_counter.rb
+++ b/test/dummy/app/models/premium_product_counter.rb
@@ -1,18 +1,16 @@
 class PremiumProductCounter < Counter::Definition
   count :premium_products
-  conditional create: ->(product) { product.premium? },
-    delete: ->(product) { product.premium? },
-    update: ->(product) {
-      became_premium = product.has_changed? :price,
-        from: ->(price) { price < 1000 },
-        to: ->(price) { price >= 1000 }
-      return 1 if became_premium
 
-      became_not_premium = product.has_changed? :price,
-        from: ->(price) { price >= 1000 },
-        to: ->(price) { price < 1000 }
-      return -1 if became_not_premium
+  on :create do
+    increment_if ->(product) { product.premium? }
+  end
 
-      return 0
-    }
+  on :delete do
+    decrement_if ->(product) { product.premium? }
+  end
+
+  on :update do
+    increment_if ->(product) { product.has_changed? :price, from: ->(price) { price < 1000 }, to: ->(price) { price >= 1000 } }
+    decrement_if ->(product) { product.has_changed? :price, from: ->(price) { price >= 1000 }, to: ->(price) { price < 1000 } }
+  end
 end


### PR DESCRIPTION
Closes #4 

Now looks like this:

```ruby
on :create do
  increment_if ->(student) { student.subscribed? && student.confirmed? }
end

on :delete do
  decrement_if ->(student) { student.subscribed? && student.confirmed? }
end

on :update do
  increment_if ->(student) { student.confirmed? && student.has_changed? :subscribed_at, from: nil }
  increment_if ->(student) { student.subscribed? && student.has_changed? :confirmed, from: false, to: true }
  decrement_if ->(student) { student.confirmed? && student.has_changed? :subscribed_at, to: nil }
  decrement_if ->(student) { student.subscribed? && student.has_changed? :confirmed, from: true, to: false }
end
```