### PR TITLE
Named counters

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Counting and aggregation library for Rails.
   - [Main concepts](#main-concepts)
   - [Defining a counter](#defining-a-counter)
   - [Accessing counter values](#accessing-counter-values)
-  - [Anonymous counters](#anonymous-counters)
+  - [Global counters](#global-counters)
   - [Defining a conditional counter](#defining-a-conditional-counter)
   - [Aggregating a value (e.g. sum of order revenue)](#aggregating-a-value-eg-sum-of-order-revenue)
   - [Recalculating a counter](#recalculating-a-counter)
@@ -94,18 +94,19 @@ end
 
 First we define the counter class itself using `count` to specify the association we're counting, then "attach" it to the parent Store model.
 
-By default, the counter will be available as `<association>_counter`, e.g. `store.orders_counter`. To customise this, pass a `as` parameter:
+By default, the counter will be available as `<association>_counter`, e.g. `store.orders_counter`. To customise this, use the `as` method:
 
 ```ruby
 class OrderCounter < Counter::Definition
   include Counter::Counters
-  count :orders, as: :total_orders
+  count :orders
+  as :total_orders
 end
 
 store.total_orders
 ```
 
-The counter's value with be stored as a `Counter::Value` with the name prefixed by the model name. e.g. `store_total_orders`
+The counter's value with be stored as a `Counter::Value` with the name prefixed by the model name. e.g. `store-total_orders`
 
 ## Accessing counter values
 
@@ -116,13 +117,13 @@ store.total_orders        #=> Counter::Value
 store.total_orders.value  #=> 200
 ```
 
-## Anonymous counters
+## Global counters
 
-Most counters are associated with a model instance and association. These counters are automatically incremented when the associated collection changes  but sometimes you just need a global counter that you can increment.
+Most counters are associated with a model instance and association. These counters are automatically incremented when the associated collection changes but sometimes you just need a global counter that you can increment.
 
 ```ruby
 class GlobalOrderCounter < Counter::Definition
-  global :my_custom_counter_name
+  global
 end
 
 GlobalOrderCounter.counter.value #=> 5

--- a/lib/counter/definition.rb
+++ b/lib/counter/definition.rb
@@ -62,7 +62,8 @@ class Counter::Definition
   # What we record in Counter::Value#name
   def record_name
     return name if global?
-    "#{model.name.underscore}-#{association_name}"
+    return "#{model.name.underscore}-#{association_name}" if association_name.present?
+    return "#{model.name.underscore}-#{name}"
   end
 
   def conditions

--- a/lib/counter/definition.rb
+++ b/lib/counter/definition.rb
@@ -89,10 +89,14 @@ class Counter::Definition
     instance.method_name = as.to_s
   end
 
-  def self.global name = nil
-    name ||= name.underscore
-    instance.name = name.to_s
+  def self.global
     Counter::Definition.instance.global_counters << instance
+  end
+
+  # Set the name of the counter
+  def self.as name
+    instance.name = name.to_s
+    instance.method_name = name.to_s
   end
 
   # Get the name of the association we're counting

--- a/lib/counter/integration/countable.rb
+++ b/lib/counter/integration/countable.rb
@@ -26,6 +26,8 @@ module Counter::Countable
     def each_counter_to_update
       # For each definition, find or create the counter on the parent
       self.class.counted_by.each do |counter_definition|
+        next unless counter_definition.inverse_association
+
         parent_association = association(counter_definition.inverse_association)
         parent_association.load_target unless parent_association.loaded?
         parent_model = parent_association.target

--- a/lib/counter/integration/counters.rb
+++ b/lib/counter/integration/counters.rb
@@ -55,34 +55,36 @@ module Counter::Counters
       counter_definitions = Array.wrap(counter_definitions)
       counter_definitions.each do |definition_class|
         definition = definition_class.instance
-        association_name = definition.association_name
-
-        # Find the association on this model
-        association_reflection = reflect_on_association(association_name)
-        # Find the association classes
-        association_class = association_reflection.class_name.constantize
-        inverse_association = association_reflection.inverse_of
-
-        raise Counter::Error.new("#{association_name} must have an inverse_of specified to be used in #{definition_class.name}") if inverse_association.nil?
-
-        # Add the after_commit hook to the association's class
-        association_class.include Counter::Countable
-        # association_class.include Counter::Changed
-
-        # Update the definition with the association class and inverse association
-        # gathered from the reflection
         definition.model = self
-        definition.inverse_association = inverse_association.name
-        definition.countable_model = association_class
 
         define_method definition.method_name do
           counters.find_or_create_counter!(definition)
         end
 
-        # Provide the Countable class with details about where it's counted
+        @counter_configs << definition unless @counter_configs.include?(definition)
 
-        @counter_configs << definition
-        association_class.add_counted_by definition
+        association_name = definition.association_name
+        if association_name.present?
+          # Find the association on this model
+          association_reflection = reflect_on_association(association_name)
+          raise Counter::Error.new("#{association_name} does not exist #{self.name}") if association_reflection.nil?
+
+          # Find the association classes
+          association_class = association_reflection.class_name.constantize
+          inverse_association = association_reflection.inverse_of
+          raise Counter::Error.new("#{association_name} must have an inverse_of specified to be used in #{definition_class.name}") if inverse_association.nil?
+
+          # Add the after_commit hook to the association's class
+          association_class.include Counter::Countable
+
+          # Update the definition with the association class and inverse association
+          # gathered from the reflection
+          definition.inverse_association = inverse_association.name
+          definition.countable_model = association_class
+
+          # Provide the Countable class with details about where it's counted
+          association_class.add_counted_by definition
+        end
       end
     end
 

--- a/test/dummy/app/models/global_order_counter.rb
+++ b/test/dummy/app/models/global_order_counter.rb
@@ -1,3 +1,4 @@
 class GlobalOrderCounter < Counter::Definition
-  global :total_orders
+  global
+  as "total_orders"
 end

--- a/test/dummy/app/models/orders_counter.rb
+++ b/test/dummy/app/models/orders_counter.rb
@@ -1,0 +1,3 @@
+class OrdersCounter < Counter::Definition
+  count :orders
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -13,5 +13,5 @@ class User < ApplicationRecord
   has_many :premium_products, -> { premium }, class_name: "Product"
   has_many :orders
 
-  counter ProductCounter, PremiumProductCounter
+  counter ProductCounter, PremiumProductCounter, OrdersCounter, VisitsCounter
 end

--- a/test/dummy/app/models/visits_counter.rb
+++ b/test/dummy/app/models/visits_counter.rb
@@ -1,3 +1,3 @@
 class VisitsCounter < Counter::Definition
-  count nil, as: "visits_counter"
+  as "visits_counter"
 end

--- a/test/dummy/app/models/visits_counter.rb
+++ b/test/dummy/app/models/visits_counter.rb
@@ -1,0 +1,3 @@
+class VisitsCounter < Counter::Definition
+  count nil, as: "visits_counter"
+end

--- a/test/integration/counters_test.rb
+++ b/test/integration/counters_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class CountersTest < ActiveSupport::TestCase
   test "configures the counters on the parent model" do
     definitions = User.counter_configs
-    assert_equal 2, definitions.length
+    assert_equal 4, definitions.length
     definition = definitions.first
     assert_equal ProductCounter, definition.class
     assert_equal User, definition.model
@@ -80,6 +80,14 @@ class CountersTest < ActiveSupport::TestCase
     # No counter for products has been created but this should
     # still work and return a new instance
     assert u.products_counter.new_record?
+  end
+
+  test "counters can just be their own thing, not associated with an association" do
+    u = User.create!
+    visits_counter = u.visits_counter
+    assert_kind_of Counter::Value, visits_counter
+    visits_counter.increment! by: 10
+    assert 10, visits_counter.value
   end
 
   test "define a global counter" do

--- a/test/integration/counters_test.rb
+++ b/test/integration/counters_test.rb
@@ -100,6 +100,10 @@ class CountersTest < ActiveSupport::TestCase
     assert GlobalOrderCounter.instance, GlobalOrderCounter.counter.definition
   end
 
+  test "sets the counter name" do
+    assert_equal "visits_counter", VisitsCounter.instance.name
+  end
+
   test "increments the counter when an item is added" do
     u = User.create
     u.products.create!


### PR DESCRIPTION
Instead of optionally specifying the name to the `count` or `global` method, have a dedicated `as` method, e.g. 

```ruby
class VisitsCounter < Counter::Definition
  as :visits
end

store.visits.value #=> 5000
```

This also allows counters which aren't associated with an association but aren't global. 