### PR TITLE
Loosen gem spec to support >= Rails 7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     counterwise (0.1.3)
-      rails (~> 7)
+      rails (>= 7)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,8 +107,8 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
-    minitest (5.18.1)
-    minitest-reporters (1.6.0)
+    minitest (5.20.0)
+    minitest-reporters (1.6.1)
       ansi
       builder
       minitest (>= 5.0)

--- a/counter.gemspec
+++ b/counter.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", "~> 7"
+  spec.add_dependency "rails", ">= 7"
 end


### PR DESCRIPTION
This PR loosens the gemspec version so we can begin testing the main application against Rails 7.1.

Additionally by upgrading to Rails 7.1 on the test app (but not committing it), we ran into an error with Minitest Reporters gem, so we updated that to resolve it. The PR that fixes the error inside minitest-reporters is: https://github.com/minitest-reporters/minitest-reporters/pull/345

## Notes
When we tried upgrading the Rails app to 7.1 for the included 'dummy' application, the specs failed with this error:

<details><summary>Error message</summary>
<p>

ERROR DefinitionTest#test_order_is_chainable (1.01s)
Minitest::UnexpectedError:         ActiveRecord::StatementInvalid: SQLite3::SQLException: no such column: products_counter_data
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/sqlite3-1.6.3-x86_64-darwin/lib/sqlite3/database.rb:152:in `initialize'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/sqlite3-1.6.3-x86_64-darwin/lib/sqlite3/database.rb:152:in `new'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/sqlite3-1.6.3-x86_64-darwin/lib/sqlite3/database.rb:152:in `prepare'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/connection_adapters/sqlite3/database_statements.rb:36:in `block (2 levels) in internal_exec_query'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract_adapter.rb:1028:in `block in with_raw_connection'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `handle_interrupt'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `block in synchronize'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract_adapter.rb:1000:in `with_raw_connection'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/connection_adapters/sqlite3/database_statements.rb:33:in `block in internal_exec_query'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract_adapter.rb:1143:in `log'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/connection_adapters/sqlite3/database_statements.rb:32:in `internal_exec_query'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract/database_statements.rb:630:in `select'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract/database_statements.rb:71:in `select_all'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract/query_cache.rb:111:in `block in select_all'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract/query_cache.rb:151:in `block in cache_sql'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `handle_interrupt'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:23:in `block in synchronize'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `handle_interrupt'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.1.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:19:in `synchronize'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract/query_cache.rb:146:in `cache_sql'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/connection_adapters/abstract/query_cache.rb:111:in `select_all'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/relation/calculations.rb:286:in `block in pluck'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/relation.rb:1003:in `skip_query_cache_if_necessary'
            /Users/andreafomera/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/activerecord-7.1.2/lib/active_record/relation/calculations.rb:282:in `pluck'
            /Users/andreafomera/Projects/counter/test/integration/definition_test.rb:139:in `block in <class:DefinitionTest>'

</p>
</details> 

So we reverted that change and kept it testing against Rails 7.0 for now until we can come back and resolve that error. It looks related to SQLite.