### PR TITLE
Fix insert race condition

### DIFF
--- a/app/models/concerns/counter/recalculatable.rb
+++ b/app/models/concerns/counter/recalculatable.rb
@@ -16,6 +16,8 @@ module Counter::Recalculatable
           on_duplicate: Arel.sql("value = counter_values.value + EXCLUDED.value"),
           record_timestamps: true
         )
+
+        reload
       end
     end
   end


### PR DESCRIPTION
Counters values are incorrect with multiple, concurrent insert transactions.

When two un-persisted instances violating the `unique_counter_values` constraint try to persist, the quickest wins and the second one raises `ActiveRecord::RecordNotUnique`.


![Untitled scene](https://github.com/podia/counter/assets/3144140/d57c4a2d-e72a-479f-9ce0-fd558296fc12)

We can solve this at the database level by using `upsert` with `on_duplicate`. When the `unique_by` constraint is violated, the code declared in `on_duplicate` is evaluated with `ON UNIQUE ("parent_type", "parent_id", "name") DO UPDATE`.