### PR TITLE
Revert fixing race condition

### DIFF
--- a/app/models/concerns/counter/recalculatable.rb
+++ b/app/models/concerns/counter/recalculatable.rb
@@ -9,15 +9,7 @@ module Counter::Recalculatable
     else
       with_lock do
         new_value = definition.sum? ? sum_by_sql : count_by_sql
-
-        self.class.upsert(
-          attributes.without("id", "created_at", "updated_at").symbolize_keys.merge(value: new_value),
-          unique_by: [:parent_type, :parent_id, :name],
-          on_duplicate: Arel.sql("value = counter_values.value + EXCLUDED.value"),
-          record_timestamps: true
-        )
-
-        reload
+        update! value: new_value
       end
     end
   end


### PR DESCRIPTION
# Why are we making this change?
Fixing race condition in #22 didn't work: it did fix the race condition but it caused normal counter updates to be summed instead of recalculated.

<img width="598" alt="SCR-20240308-piuf" src="https://github.com/podia/counter/assets/23638317/de7fa206-2b50-4e32-a19e-5421ae2735a5">

# What are you changing?
Reverting the change from #22.