### PR TITLE
Manually calculated values

### DIFF
--- a/app/models/concerns/counter/conditional.rb
+++ b/app/models/concerns/counter/conditional.rb
@@ -11,6 +11,7 @@ module Counter::Conditional
     end
 
     def accept_item? item, on, increment: true
+      return false if definition.calculated_value?
       return true unless definition.conditional?
 
       conditions = definition.conditions[on]

--- a/app/models/concerns/counter/increment.rb
+++ b/app/models/concerns/counter/increment.rb
@@ -19,18 +19,33 @@ module Counter::Increment
     end
 
     def add_item item
+      if definition.calculated_value?
+        recalc!
+        return
+      end
+
       return unless increment?(item, :create)
 
       increment! by: increment_from_item(item)
     end
 
     def remove_item item
+      if definition.calculated_value?
+        recalc!
+        return
+      end
+
       return unless decrement?(item, :delete)
 
       decrement! by: increment_from_item(item)
     end
 
     def update_item item
+      if definition.calculated_value?
+        recalc!
+        return
+      end
+
       if increment?(item, :update)
         increment! by: increment_from_item(item)
       end

--- a/app/models/concerns/counter/recalculatable.rb
+++ b/app/models/concerns/counter/recalculatable.rb
@@ -2,7 +2,9 @@ module Counter::Recalculatable
   extend ActiveSupport::Concern
 
   def recalc!
-    if definition.calculated?
+    if definition.calculated_value?
+      recalculate_with_value!
+    elsif definition.calculated?
       calculate!
     elsif definition.manual?
       raise Counter::Error.new("Can't recalculate a manual counter")
@@ -25,5 +27,13 @@ module Counter::Recalculatable
   # use this scope when recalculating the value
   def recalc_scope
     parent.association(definition.association_name).scope
+  end
+
+  private
+
+  def recalculate_with_value!
+    with_lock do
+      update!(value: definition.calculated_value.call(parent))
+    end
   end
 end

--- a/lib/counter/definition.rb
+++ b/lib/counter/definition.rb
@@ -36,6 +36,8 @@ class Counter::Definition
   attr_accessor :calculated_from
   # The block used to manually set the value
   attr_accessor :calculated_value
+  # The counter's record name
+  attr_writer :record_name
 
   # Is this a counter which sums a column?
   def sum?
@@ -81,8 +83,13 @@ class Counter::Definition
     Counter::Value.find_counter self
   end
 
+  def self.record_name(value)
+    instance.record_name = value.to_s
+  end
+
   # What we record in Counter::Value#name
   def record_name
+    return @record_name if @record_name.present?
     return name if global?
     return "#{model.name.underscore}-#{association_name}" if association_name.present?
     "#{model.name.underscore}-#{name}"

--- a/lib/counter/definition.rb
+++ b/lib/counter/definition.rb
@@ -113,6 +113,12 @@ class Counter::Definition
 
   def self.calculated_value(&block)
     instance.calculated_value = block
+    set_default_name
+  end
+
+  def self.set_default_name
+    instance.name ||= to_s.underscore
+    instance.method_name ||= to_s.underscore
   end
 
   def self.global

--- a/lib/counter/definition.rb
+++ b/lib/counter/definition.rb
@@ -52,6 +52,11 @@ class Counter::Definition
     @conditional
   end
 
+  # Is this counter using a calculated value?
+  def calculated_value?
+    @calculated_value.present?
+  end
+
   # Is this counter calculated from other counters?
   def calculated?
     !@calculated_from.nil?

--- a/lib/counter/definition.rb
+++ b/lib/counter/definition.rb
@@ -123,8 +123,8 @@ class Counter::Definition
     instance.method_name = as.to_s
   end
 
-  def self.calculated_value(association_name, calculation)
-    instance.association_name = association_name
+  def self.calculated_value(calculation, association: nil)
+    instance.association_name = association
     instance.calculated_value = calculation
     set_default_name
   end

--- a/lib/counter/definition.rb
+++ b/lib/counter/definition.rb
@@ -116,8 +116,9 @@ class Counter::Definition
     instance.method_name = as.to_s
   end
 
-  def self.calculated_value(&block)
-    instance.calculated_value = block
+  def self.calculated_value(association_name, calculation)
+    instance.association_name = association_name
+    instance.calculated_value = calculation
     set_default_name
   end
 

--- a/lib/counter/definition.rb
+++ b/lib/counter/definition.rb
@@ -34,6 +34,8 @@ class Counter::Definition
   attr_writer :dependent_counters
   # The block to call to calculate the counter
   attr_accessor :calculated_from
+  # The block used to manually set the value
+  attr_accessor :calculated_value
 
   # Is this a counter which sums a column?
   def sum?
@@ -107,6 +109,10 @@ class Counter::Definition
     instance.name = as.to_s
     # How the counter can be accessed e.g. counter.products_counter
     instance.method_name = as.to_s
+  end
+
+  def self.calculated_value(&block)
+    instance.calculated_value = block
   end
 
   def self.global

--- a/lib/counter/definition.rb
+++ b/lib/counter/definition.rb
@@ -78,7 +78,7 @@ class Counter::Definition
   def record_name
     return name if global?
     return "#{model.name.underscore}-#{association_name}" if association_name.present?
-    return "#{model.name.underscore}-#{name}"
+    "#{model.name.underscore}-#{name}"
   end
 
   def conditions

--- a/test/dummy/app/models/cigarette_counter.rb
+++ b/test/dummy/app/models/cigarette_counter.rb
@@ -1,0 +1,3 @@
+class CigaretteCounter < Counter::Definition
+  calculated_value ->(user) { user.grumpy? ? 212 : 4 }
+end

--- a/test/dummy/app/models/returned_order_counter.rb
+++ b/test/dummy/app/models/returned_order_counter.rb
@@ -1,0 +1,4 @@
+class ReturnedOrderCounter < Counter::Definition
+  calculated_value ->(order) { 500 }, association: :orders
+  record_name :users_returned_orders
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -16,4 +16,8 @@ class User < ApplicationRecord
 
   counter ProductCounter, PremiumProductCounter, OrdersCounter, VisitsCounter
   counter ConversionRateCounter
+  counter CigaretteCounter
+  counter ReturnedOrderCounter
+
+  def grumpy! = update!(grumpy: true)
 end

--- a/test/dummy/db/migrate/20250828185102_add_grumpy_to_users.rb
+++ b/test/dummy/db/migrate/20250828185102_add_grumpy_to_users.rb
@@ -1,0 +1,5 @@
+class AddGrumpyToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :grumpy, :boolean, default: false
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_07_30_141956) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_28_185102) do
   create_table "counter_values", force: :cascade do |t|
     t.string "name"
     t.decimal "value", default: "0.0", null: false
@@ -63,6 +63,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_07_30_141956) do
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "grumpy", default: false
   end
 
   add_foreign_key "orders", "products"

--- a/test/integration/conditional_test.rb
+++ b/test/integration/conditional_test.rb
@@ -28,4 +28,12 @@ class ConditionalTest < ActiveSupport::TestCase
     product.destroy
     assert_equal 0, u.premium_products_counter.value
   end
+
+  test "calculated values never accept item" do
+    user = User.create!
+    product = Product.create!(user:, price: 1000)
+
+    order = Order.create!(user:, product:, price: 1000)
+    refute user.returned_order_counter.accept_item?(order, "x")
+  end
 end

--- a/test/integration/definition_test.rb
+++ b/test/integration/definition_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class DefinitionTest < ActiveSupport::TestCase
   test "configures the counters on the parent model" do
     definitions = User.counter_configs
-    assert_equal 5, definitions.length
+    assert_equal 7, definitions.length
     definition = definitions.first
     assert_equal ProductCounter, definition.class
     assert_equal User, definition.model
@@ -167,5 +167,23 @@ class DefinitionTest < ActiveSupport::TestCase
     product.orders.create! price: 10, user: u
     assert_kind_of Counter::Value, product.order_revenue
     assert 10, product.order_revenue.value
+  end
+
+  test "calculated values can be defined" do
+    assert_kind_of Proc, CigaretteCounter.instance.calculated_value
+  end
+
+  test "calculated values can define an association" do
+    assert_kind_of Proc, ReturnedOrderCounter.instance.calculated_value
+    assert_equal :orders, ReturnedOrderCounter.instance.association_name
+  end
+
+  test "calculated values set a default name" do
+    assert_equal "cigarette_counter", CigaretteCounter.instance.name
+    assert_equal "cigarette_counter", CigaretteCounter.instance.method_name
+  end
+
+  test "value record names can be defined" do
+    assert_equal "users_returned_orders", ReturnedOrderCounter.instance.record_name
   end
 end

--- a/test/integration/increment_test.rb
+++ b/test/integration/increment_test.rb
@@ -47,8 +47,25 @@ class CountersTest < ActiveSupport::TestCase
     assert_equal nil, counter
 
     subscription_coupon.destroy!
-    product_coupon = product.coupons.create!(amount: 500)
+    _product_coupon = product.coupons.create!(amount: 500)
     counter = product.counters.find_counter(ProductDiscountsCounter)
     assert_equal 500, counter.reload.value
+  end
+
+  test "calculated values do not incremement or decrement" do
+    user = User.create!
+    product = Product.create!(user:, price: 1000)
+
+    Order.create!(user:, product:, price: 1000)
+    assert_equal 500, user.returned_order_counter.value
+
+    Order.create!(user:, product:, price: 1000)
+    assert_equal 500, user.returned_order_counter.value
+
+    user.orders.last.update!(price: 100000000)
+    assert_equal 500, user.returned_order_counter.value
+
+    Order.destroy_all
+    assert_equal 500, user.returned_order_counter.value
   end
 end

--- a/test/integration/recalc_test.rb
+++ b/test/integration/recalc_test.rb
@@ -37,4 +37,18 @@ class RecalcTest < ActiveSupport::TestCase
     u.conversion_rate.recalc!
     assert_equal 2, u.conversion_rate.value
   end
+
+  test "calculated_values recalculate from their callable" do
+    u = User.create!(grumpy: false)
+
+    u.cigarette_counter.reset!
+    assert_equal 0, u.cigarette_counter.value
+
+    u.cigarette_counter.recalc!
+    assert_equal 4, u.cigarette_counter.value.to_i
+
+    u.grumpy!
+    u.cigarette_counter.recalc!
+    assert_equal 212, u.cigarette_counter.value.to_i
+  end
 end


### PR DESCRIPTION
It would be of much benefit to me, someone who needs to do a count on a `has_many :x, through: :y`, if I had a way to just manually tell the counter what it's value should be when it runs.

I'm proposing a `calculated_value` declaration that take a "callable" to get the manual count and also takes an optional association to listen for associated changes on.

Some niceties for myself include:

* Automatically setting the counter name (`set_default_name`) without having to provide `as:`
* Exposing the `record_name` option used for the `Counter::Value#name`