### PR TITLE
STI fix

### DIFF
--- a/lib/counter/integration/countable.rb
+++ b/lib/counter/integration/countable.rb
@@ -33,7 +33,7 @@ module Counter::Countable
         parent_model = parent_association.target
         next unless parent_model
 
-        if parent_model.class.reflect_on_association(:counters) && parent_model.class == counter_definition.model
+        if parent_model.class.reflect_on_association(:counters) && parent_model.is_a?(counter_definition.model)
           counter = parent_model.counters.find_or_create_counter!(counter_definition)
           yield counter if counter
         end

--- a/test/dummy/app/models/admin_user.rb
+++ b/test/dummy/app/models/admin_user.rb
@@ -1,0 +1,11 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :integer          not null, primary key
+#  type       :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class AdminUser < User
+end

--- a/test/dummy/db/migrate/20260518120000_add_type_to_users.rb
+++ b/test/dummy/db/migrate/20260518120000_add_type_to_users.rb
@@ -1,0 +1,5 @@
+class AddTypeToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :type, :string
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_28_185102) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_18_120000) do
   create_table "counter_values", force: :cascade do |t|
     t.string "name"
     t.decimal "value", default: "0.0", null: false
@@ -64,6 +64,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_28_185102) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "grumpy", default: false
+    t.string "type"
   end
 
   add_foreign_key "orders", "products"

--- a/test/integration/increment_test.rb
+++ b/test/integration/increment_test.rb
@@ -68,4 +68,20 @@ class CountersTest < ActiveSupport::TestCase
     Order.destroy_all
     assert_equal 500, user.returned_order_counter.value
   end
+
+  test "increments the parent counter when parent is an STI subclass" do
+    admin = AdminUser.create!
+    admin.products.create!
+    counter = admin.counters.find_or_create_counter! ProductCounter
+    assert_equal 1, counter.value
+  end
+
+  test "updates the parent counter on item update when parent is an STI subclass" do
+    admin = AdminUser.create!
+    product = admin.products.create!(price: 100)
+    counter = admin.counters.find_or_create_counter!(PremiumProductCounter)
+    assert_equal 0, counter.value
+    product.update!(price: 2000)
+    assert_equal 1, counter.reload.value
+  end
 end

--- a/test/integration/increment_test.rb
+++ b/test/integration/increment_test.rb
@@ -79,9 +79,8 @@ class CountersTest < ActiveSupport::TestCase
   test "updates the parent counter on item update when parent is an STI subclass" do
     admin = AdminUser.create!
     product = admin.products.create!(price: 100)
-    counter = admin.counters.find_or_create_counter!(PremiumProductCounter)
-    assert_equal 0, counter.value
+    assert_nil admin.counters.find_counter(PremiumProductCounter)
     product.update!(price: 2000)
-    assert_equal 1, counter.reload.value
+    assert_equal 1, admin.counters.find_counter(PremiumProductCounter).value
   end
 end


### PR DESCRIPTION
## Problem

Counter updates are only triggered when the parent's class **exactly** matches the class declared in the counter definition. STI subclasses are never matched, so any model whose parent is an STI subclass silently fails to update its counters.

The offending check in `lib/counter/integration/countable.rb`:

```ruby
if parent_model.class.reflect_on_association(:counters) && parent_model.class == counter_definition.model
```

`==` here rejects subclasses. Given:

```ruby
class User < ApplicationRecord
  has_many :products
  counter ProductCounter
end

class AdminUser < User
end

admin = AdminUser.create!
admin.products.create!
admin.counters.find_counter(ProductCounter) # => nil  ❌
```

The `ProductCounter` is registered against `User`, but `AdminUser.class == User` is false, so the increment is skipped.

## Fix

Replace the exact-class equality with `is_a?`, which honours inheritance:

```ruby
if parent_model.class.reflect_on_association(:counters) && parent_model.is_a?(counter_definition.model)
```

This preserves the original intent (only fire when the parent actually has the counter registered) while allowing STI subclasses through.

## Tests

Two integration tests added covering both code paths:

- `increments the parent counter when parent is an STI subclass` — `after_create` callback
- `updates the parent counter on item update when parent is an STI subclass` — `after_update` callback (exercises `PremiumProductCounter`'s update-driven increment)

Test setup adds an `AdminUser < User` STI subclass and the corresponding `type` column on `users`.