### PR TITLE
Fix Counter#correct! to heal drift and handle manual counters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    counterwise (0.1.7)
+    counterwise (0.1.8)
       rails (>= 8)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    counterwise (0.1.6)
+    counterwise (0.1.7)
       rails (>= 8)
 
 GEM

--- a/app/models/concerns/counter/verifyable.rb
+++ b/app/models/concerns/counter/verifyable.rb
@@ -2,25 +2,29 @@ module Counter::Verifyable
   extend ActiveSupport::Concern
 
   def correct?
-    # We can't verify these values
-    return true if definition.global?
+    # We can't verify these values: manual counters (which includes globals)
+    # have no countable source of truth, so their stored value is authoritative.
+    return true if definition.manual?
 
-    old_value, new_value = verify
-    old_value == new_value
+    correct_value, current_value = verify
+    correct_value == current_value
   end
 
   def correct!
-    # We can't verify these values
-    return true if definition.global?
+    # We can't verify these values: manual counters (which includes globals)
+    # have no countable source of truth, so their stored value is authoritative.
+    return true if definition.manual?
 
-    old_value, new_value = verify
+    correct_value, current_value = verify
 
-    requires_recalculation = old_value != new_value
-    update! value: new_value if requires_recalculation
+    requires_recalculation = correct_value != current_value
+    update! value: correct_value if requires_recalculation
 
     !requires_recalculation
   end
 
+  # Returns [correct_value, current_value]: the value recomputed from live
+  # data, and the value currently stored on the counter.
   def verify
     if definition.calculated?
       [calculate, value]
@@ -43,7 +47,7 @@ module Counter::Verifyable
         counter = counters.where("id >= ?", random_id).limit(1).first
         next if counter.nil?
 
-        if counter.definition.global? || counter.definition.calculated?
+        if counter.definition.manual? || counter.definition.calculated?
           puts "➡️ Skipping counter #{counter.name} (#{counter.id})" if verbose
           next
         end

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "setup": "bundle install && bin/rails db:test:prepare",
+    "run": "bin/rails test"
+  },
+  "runScriptMode": "concurrent"
+}

--- a/lib/counter/version.rb
+++ b/lib/counter/version.rb
@@ -1,3 +1,3 @@
 module Counter
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end

--- a/test/integration/verify_test.rb
+++ b/test/integration/verify_test.rb
@@ -11,7 +11,20 @@ class VerifyTest < ActiveSupport::TestCase
     counter.reset!
     assert !counter.correct?
     assert_equal false, counter.correct!
-    assert 1, counter.value
+    # correct! heals the drift by writing the recomputed value back
+    assert counter.correct?
+    assert_equal 1, counter.reload.value
+  end
+
+  test "manual counters are always considered correct" do
+    u = User.create
+    u.visits_counter.increment! by: 5
+    assert u.visits_counter.definition.manual?
+    # Manual counters have no countable source of truth, so they can't drift
+    # and must not raise when run through the verification API.
+    assert u.visits_counter.correct?
+    assert_equal true, u.visits_counter.correct!
+    assert_equal 5, u.visits_counter.reload.value
   end
 
   test "verifies a calculated counter" do
@@ -26,7 +39,7 @@ class VerifyTest < ActiveSupport::TestCase
     u = User.create
     u.products.create!
     u.products_counter.increment! by: 2
-    assert [1, 3], u.products_counter.verify
+    assert_equal [1, 3], u.products_counter.verify
   end
 
   test "sample_and_verify" do


### PR DESCRIPTION
`Counter::Value#correct!` was writing the stored (drifted) value back to itself instead of the recomputed value, so it never actually healed drift; this renames the `verify` pair to `correct_value`/`current_value` and writes the recomputed value, with the contract documented on `verify`. It also treats manual counters (a superset of global counters, with no countable source of truth) as unverifiable in `correct?`/`correct!`/`sample_and_verify`, so they return "correct" instead of crashing on `parent.association(nil)`. Tests are added/strengthened for both behaviors (the prior `assert`-without-`assert_equal` no-ops are fixed), and the full suite passes. Also bumps `Gemfile.lock` to `counterwise 0.1.7` to match `version.rb`, and adds a shared `conductor.json` (Bundler setup + DB prepare, `bin/rails test` as the run script, concurrent mode).