### PR TITLE
Require RubyGems MFA for gem releases

### DIFF
--- a/counter.gemspec
+++ b/counter.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/podia/counter"
   spec.metadata["changelog_uri"] = "https://github.com/podia/counter/CHANGELOG.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 


### PR DESCRIPTION
Adds `spec.metadata["rubygems_mfa_required"] = "true"` to the gemspec so that multi-factor authentication is required for privileged actions (such as publishing) on the gem at RubyGems.org. This is a security hardening change with no impact on gem consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)